### PR TITLE
Globalheader

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -4,8 +4,8 @@ import { Suspense } from 'react';
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer>
-      { /* Mark EmployeeDetailsContainer as CSR */ }
+    <GlobalContainer pageTitle="社員詳細">
+      {/* Mark EmployeeDetailsContainer as CSR */}
       <Suspense>
         <EmployeeDetailsContainer />
       </Suspense>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -3,7 +3,7 @@ import { GlobalContainer } from "@/components/GlobalContainer";
 
 export default function Home() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageTitle="社員検索">
       <SearchEmployees />
     </GlobalContainer>
   );

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,13 +3,12 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 
-export function GlobalContainer({
-  children,
-  pageTitle,
-}: {
+export interface GlobalContainerProps {
   children: React.ReactNode;
   pageTitle: string;
-}) {
+}
+
+export function GlobalContainer({ children, pageTitle }: GlobalContainerProps) {
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,13 +3,22 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 
-export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+export function GlobalContainer({
+  children,
+  pageTitle,
+}: {
+  children: React.ReactNode;
+  pageTitle: string;
+}) {
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
+        <GlobalHeader
+          title={"タレントマネジメントシステム"}
+          subtitle={pageTitle}
+        />
       </header>
 
       <VerticalSpacer height={32} />

--- a/frontend/src/components/GlobalHeader.tsx
+++ b/frontend/src/components/GlobalHeader.tsx
@@ -4,9 +4,12 @@ import Link from "next/link";
 
 export interface GlobalHeaderProps {
   title: string;
+  subtitle: string;
 }
 
-export function GlobalHeader({ title }: GlobalHeaderProps) {
+export function GlobalHeader({ title, subtitle }: GlobalHeaderProps) {
+  const displayTitle = `${title} - ${subtitle}`;
+
   return (
     <Box sx={{ flexGrow: 1 }}>
       <AppBar position="static">
@@ -22,7 +25,7 @@ export function GlobalHeader({ title }: GlobalHeaderProps) {
           </Link>
           <Link href="/">
             <Typography variant="h6" component="h1" sx={{ flexGrow: 1 }}>
-              {title}
+              {displayTitle}
             </Typography>
           </Link>
         </Toolbar>


### PR DESCRIPTION
## 概要
グローバルヘッダーに現在のページタイトルを動的に表示する機能を追加しました。

## 表示結果
- **ホームページ**: 「タレントマネジメントシステム - 社員検索」
- **社員詳細ページ**: 「タレントマネジメントシステム - 社員詳細」

## 実装方法
新しいページを追加する際は、以下のようにpageTitleを指定することで対応できます：

```tsx
<GlobalContainer pageTitle="新機能ページ">
  <NewFeatureComponent />
</GlobalContainer>
```

### 以下はLLMとの会話の履歴です

export interfaceでコンポーネントの中身を受け取るための方法の質問
https://chatgpt.com/share/6868917b-997c-800f-bba2-19046b9f386f

コードのテストのためテストページの生成
[chat.md](https://github.com/user-attachments/files/21071261/chat.md)
