### PR TITLE
No.2　ウィンドウタイトルをページ毎に変更する

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -1,11 +1,16 @@
 import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer";
 import { GlobalContainer } from "@/components/GlobalContainer";
-import { Suspense } from 'react';
+import { Suspense } from "react";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "タレントマネジメントシステム - 従業員詳細",
+  description: "シンプルなタレントマネジメントシステム",
+};
 
 export default function EmployeePage() {
   return (
     <GlobalContainer>
-      { /* Mark EmployeeDetailsContainer as CSR */ }
       <Suspense>
         <EmployeeDetailsContainer />
       </Suspense>

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -4,7 +4,7 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "従業員",
+  title: "社員詳細",
 };
 
 export default function EmployeePage() {

--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -4,8 +4,7 @@ import { Suspense } from "react";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "タレントマネジメントシステム - 従業員詳細",
-  description: "シンプルなタレントマネジメントシステム",
+  title: "従業員",
 };
 
 export default function EmployeePage() {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,3 +1,4 @@
+import { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -11,6 +12,14 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
+
+export const metadata: Metadata = {
+  title: {
+    default: "タレントマネジメントシステム",
+    template: "タレントマネジメントシステム - %s",
+  },
+  description: "シンプルなタレントマネジメントシステム",
+};
 
 export default function RootLayout({
   children,

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { AppRouterCacheProvider } from "@mui/material-nextjs/v15-appRouter";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -12,11 +11,6 @@ const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
 });
-
-export const metadata: Metadata = {
-  title: "タレントマネジメントシステム",
-  description: "シンプルなタレントマネジメントシステム",
-};
 
 export default function RootLayout({
   children,

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,11 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "タレントマネジメントシステム",
+  description: "シンプルなタレントマネジメントシステム",
+};
 
 export default function Home() {
   return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,5 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
-import { Metadata } from "next";
-
-export const metadata: Metadata = {
-  title: "タレントマネジメントシステム",
-  description: "シンプルなタレントマネジメントシステム",
-};
 
 export default function Home() {
   return (

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,10 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "社員検索",
+};
 
 export default function Home() {
   return (


### PR DESCRIPTION
# 概要
ウィンドウタイトルをページ毎に変更するようにしました。

# 詳細
layout.tsxのMetadataのtitleを変更し、各コンポーネントからタイトルを変更できるようにしました。

# 実装
layout.tsxのMetadataを以下のように実装。
```
export const metadata: Metadata = {
  title: {
    default: "タレントマネジメントシステム",
    template: "タレントマネジメントシステム - %s",
  },
  description: "シンプルなタレントマネジメントシステム",
};
```
各page.tsxで以下のようにMetdataを呼び出すことでウィンドウタイトルを変更できる。
```
export const metadata: Metadata = {
  title: "社員詳細",
};
```

参考URL
https://commte.net/nextjs-metadata