### PR TITLE
Task1: Implement partial match search on a name 

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseDynamoDB.ts
@@ -47,7 +47,11 @@ export class EmployeeDatabaseDynamoDB implements EmployeeDatabase {
             return [];
         }
         return items
-            .filter(item => filterText === "" || item["name"].S === filterText)
+            .filter(item => {
+                const name = (item["name"]?.S ?? "").toLowerCase();
+                const keyword = filterText.toLowerCase();
+                return keyword === "" || name.includes(keyword);
+            })
             .map(item => {
                 return {
                     id: item["id"].S,

--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -20,6 +20,7 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
         if (filterText === "") {
             return employees;
         }
-        return employees.filter(employee => employee.name === filterText);
+        return employees.filter(employee => employee.name.includes(filterText) // 部分一致に変更
+    );
     }
 }


### PR DESCRIPTION
### 概要
苗字や名前のみでも検索できるようにしました。

###詳細
employee.name === filterTextの部分をemployee.name.includes(filterText)に変更し、入力した文字列が含まれていたら検索にヒットするように変更しました。
現在動いているのはEmployeeDatabaseInMemory.tsですが、AWSにデプロイした際はEmployeeDatabase DynamoDB.tsで動くのでこちらも変更しました。

###生成AIの利用について
以下はLLMとの会話履歴です。
https://chatgpt.com/share/6868dc22-f1f0-8006-9eed-a3ad7666a1ae
https://chatgpt.com/share/6868dc36-b36c-8006-8faf-51956cb2a47f